### PR TITLE
resource mapping for list handlers

### DIFF
--- a/Fastly-Tls-Certificate/src/handlers.ts
+++ b/Fastly-Tls-Certificate/src/handlers.ts
@@ -28,13 +28,16 @@ class Resource extends AbstractFastlyResource<ResourceModel, CertificatePayload,
         return response.response.body.data;
     }
 
-    async list(typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
+    async list(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
         Fastly.ApiClient.instance.authenticate(typeConfiguration?.fastlyAccess.token);
         Fastly.ApiClient.instance.defaultHeaders = {
             'User-Agent': this.userAgent
         };
-        const response: ResponseWithHttpInfo<CertificatePayload[]> = await new Fastly.TlsCertificatesApi().listTlsCertsWithHttpInfo();
-        return response.data;
+        const response: ResponseWithHttpInfo<CertificatePayload> = await new Fastly.TlsCertificatesApi().listTlsCertsWithHttpInfo();
+        
+        return response.response.body.data.map((pk: any) => {
+            return this.setModelFrom(new ResourceModel(), pk);
+        });
     }
 
     async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<CertificatePayload> {

--- a/Fastly-Tls-Domain/src/handlers.ts
+++ b/Fastly-Tls-Domain/src/handlers.ts
@@ -34,8 +34,11 @@ class Resource extends AbstractFastlyResource<ResourceModel, DomainPayload, Doma
         Fastly.ApiClient.instance.defaultHeaders = {
             'User-Agent': this.userAgent
         };
-        const response: ResponseWithHttpInfo<DomainPayload[]> = await new Fastly.TlsDomainsApi().listTlsDomainsWithHttpInfo();
-        return response.data;
+        const response: ResponseWithHttpInfo<DomainPayload> = await new Fastly.TlsDomainsApi().listTlsDomainsWithHttpInfo();
+
+        return response.response.body.data.map((pk: any) => {
+            return this.setModelFrom(new ResourceModel(), pk);
+        });
     }
 
     async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<DomainPayload> {

--- a/Fastly-Tls-PrivateKeys/src/handlers.ts
+++ b/Fastly-Tls-PrivateKeys/src/handlers.ts
@@ -29,13 +29,16 @@ class Resource extends AbstractFastlyResource<ResourceModel, PrivateKeysPayload,
         return response.response.body.data;
     }
 
-    async list(typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
+    async list(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
         Fastly.ApiClient.instance.authenticate(typeConfiguration?.fastlyAccess.token);
         Fastly.ApiClient.instance.defaultHeaders = {
             'User-Agent': this.userAgent
         };
-        const response: ResponseWithHttpInfo<PrivateKeysPayload[]> = await new Fastly.TlsPrivateKeysApi().listTlsKeysWithHttpInfo();
-        return response.data;
+        const response: ResponseWithHttpInfo<PrivateKeysPayload> = await new Fastly.TlsPrivateKeysApi().listTlsKeysWithHttpInfo();
+        
+        return response.response.body.data.map((pk: any) => {
+            return this.setModelFrom(new ResourceModel(), pk);
+        });
     }
 
     async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<PrivateKeysPayload> {


### PR DESCRIPTION
List method did not accept a `model` as first parameter hence the ctv1 test were failing for all new Fastly resources, and return types have to be mapped to ResourceModel.