### PR TITLE
Make version Ids consistent

### DIFF
--- a/Fastly-Dictionary-Dictionary/docs/README.md
+++ b/Fastly-Dictionary-Dictionary/docs/README.md
@@ -15,7 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#deletedat" title="DeletedAt">DeletedAt</a>" : <i>String</i>,
         "<a href="#serviceid" title="ServiceId">ServiceId</a>" : <i>String</i>,
-        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>String</i>,
+        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>Double</i>,
     }
 }
 </pre>
@@ -28,7 +28,7 @@ Properties:
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#deletedat" title="DeletedAt">DeletedAt</a>: <i>String</i>
     <a href="#serviceid" title="ServiceId">ServiceId</a>: <i>String</i>
-    <a href="#versionid" title="VersionId">VersionId</a>: <i>String</i>
+    <a href="#versionid" title="VersionId">VersionId</a>: <i>Double</i>
 </pre>
 
 ## Properties
@@ -65,11 +65,11 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### VersionId
 
-Alphanumeric string identifying the service version.
+Id identifying the service version.
 
 _Required_: Yes
 
-_Type_: String
+_Type_: Double
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Dictionary-Dictionary/example-inputs/inputs_1_create.json
+++ b/Fastly-Dictionary-Dictionary/example-inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
   "ServiceId": "<FASTLY_SERVICE_ID>",
-  "VersionId": "<FASTLY_VERSION_ID>",
+  "VersionId": <FASTLY_VERSION_ID>,
   "Name": "<RANDOM_DICTIONARY>"
 }

--- a/Fastly-Dictionary-Dictionary/fastly-dictionary-dictionary.json
+++ b/Fastly-Dictionary-Dictionary/fastly-dictionary-dictionary.json
@@ -64,8 +64,8 @@
             "format": "date-time"
         },
         "VersionId": {
-            "description": "Alphanumeric string identifying the service version.",
-            "type": "string"
+            "description": "Id identifying the service version.",
+            "type": "number"
         },
         "Version": {
             "description": "Integer identifying a domain version. Read-only.",

--- a/Fastly-Dictionary-Dictionary/src/models.ts
+++ b/Fastly-Dictionary-Dictionary/src/models.ts
@@ -81,12 +81,12 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'VersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'versionId', value, obj, []),
+            transformValue(Number, 'versionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    versionId?: Optional<string>;
+    versionId?: Optional<number>;
     @Expose({ name: 'Version' })
     @Transform(
         (value: any, obj: any) =>

--- a/Fastly-Logging-S3/docs/README.md
+++ b/Fastly-Logging-S3/docs/README.md
@@ -33,7 +33,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#serversideencryption" title="ServerSideEncryption">ServerSideEncryption</a>" : <i>String</i>,
         "<a href="#serversideencryptionkmskeyid" title="ServerSideEncryptionKmsKeyId">ServerSideEncryptionKmsKeyId</a>" : <i>String</i>,
         "<a href="#serviceid" title="ServiceId">ServiceId</a>" : <i>String</i>,
-        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>String</i>,
+        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>Double</i>,
         "<a href="#version" title="Version">Version</a>" : <i>String</i>
     }
 }
@@ -65,7 +65,7 @@ Properties:
     <a href="#serversideencryption" title="ServerSideEncryption">ServerSideEncryption</a>: <i>String</i>
     <a href="#serversideencryptionkmskeyid" title="ServerSideEncryptionKmsKeyId">ServerSideEncryptionKmsKeyId</a>: <i>String</i>
     <a href="#serviceid" title="ServiceId">ServiceId</a>: <i>String</i>
-    <a href="#versionid" title="VersionId">VersionId</a>: <i>String</i>
+    <a href="#versionid" title="VersionId">VersionId</a>: <i>Double</i>
     <a href="#version" title="Version">Version</a>: <i>String</i>
 </pre>
 
@@ -291,11 +291,11 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### VersionId
 
-Alphanumeric string identifying the service version.
+Id identifying the service version.
 
 _Required_: No
 
-_Type_: String
+_Type_: Double
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Logging-S3/example-inputs/inputs_1_create.json
+++ b/Fastly-Logging-S3/example-inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
   "ServiceId": "<FASTLY_SERVICE_ID>",
-  "VersionId": "<FASTLY_VERSION_ID>",
+  "VersionId": <FASTLY_VERSION_ID>,
   "AccessKey": "AKIAIOSFODNN7EXAMPLE",
   "SecretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
   "Name": "<RANDOM_NAME>",

--- a/Fastly-Logging-S3/fastly-logging-s3.json
+++ b/Fastly-Logging-S3/fastly-logging-s3.json
@@ -151,8 +151,8 @@
             "format": "date-time"
         },
         "VersionId": {
-            "description": "Alphanumeric string identifying the service version.",
-            "type": "string"
+            "description": "Id identifying the service version.",
+            "type": "number"
         },
         "Version": {
             "description": "Integer identifying a domain version. Read-only.",

--- a/Fastly-Logging-S3/src/models.ts
+++ b/Fastly-Logging-S3/src/models.ts
@@ -232,12 +232,12 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'VersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'versionId', value, obj, []),
+            transformValue(Number, 'versionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    versionId?: Optional<string>;
+    versionId?: Optional<number>;
     @Expose({ name: 'Version' })
     @Transform(
         (value: any, obj: any) =>

--- a/Fastly-Logging-Splunk/docs/README.md
+++ b/Fastly-Logging-Splunk/docs/README.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#url" title="Url">Url</a>" : <i>String</i>,
         "<a href="#usetls" title="UseTls">UseTls</a>" : <i>Integer</i>,
         "<a href="#serviceid" title="ServiceId">ServiceId</a>" : <i>String</i>,
-        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>String</i>,
+        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>Double</i>,
         "<a href="#version" title="Version">Version</a>" : <i>String</i>
     }
 }
@@ -51,7 +51,7 @@ Properties:
     <a href="#url" title="Url">Url</a>: <i>String</i>
     <a href="#usetls" title="UseTls">UseTls</a>: <i>Integer</i>
     <a href="#serviceid" title="ServiceId">ServiceId</a>: <i>String</i>
-    <a href="#versionid" title="VersionId">VersionId</a>: <i>String</i>
+    <a href="#versionid" title="VersionId">VersionId</a>: <i>Double</i>
     <a href="#version" title="Version">Version</a>: <i>String</i>
 </pre>
 
@@ -205,11 +205,11 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### VersionId
 
-Alphanumeric string identifying the service version.
+Id identifying the service version.
 
 _Required_: No
 
-_Type_: String
+_Type_: Double
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Logging-Splunk/example-inputs/inputs_1_create.json
+++ b/Fastly-Logging-Splunk/example-inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
   "ServiceId": "<FASTLY_SERVICE_ID>",
-  "VersionId": "<FASTLY_VERSION_ID>",
+  "VersionId": <FASTLY_VERSION_ID>,
   "Name": "<RANDOM_NAME>",
   "Token": "MySplunkToken",
   "Url": "https://mysplunkhost:8088/services/collector/event/1.0"

--- a/Fastly-Logging-Splunk/fastly-logging-splunk.json
+++ b/Fastly-Logging-Splunk/fastly-logging-splunk.json
@@ -116,8 +116,8 @@
             "format": "date-time"
         },
         "VersionId": {
-            "description": "Alphanumeric string identifying the service version.",
-            "type": "string"
+            "description": "Id identifying the service version.",
+            "type": "number"
         },
         "Version": {
             "description": "Integer identifying a domain version. Read-only.",

--- a/Fastly-Logging-Splunk/src/models.ts
+++ b/Fastly-Logging-Splunk/src/models.ts
@@ -169,12 +169,12 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'VersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'versionId', value, obj, []),
+            transformValue(Number, 'versionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    versionId?: Optional<string>;
+    versionId?: Optional<number>;
     @Expose({ name: 'Version' })
     @Transform(
         (value: any, obj: any) =>

--- a/Fastly-Services-Backend/docs/README.md
+++ b/Fastly-Services-Backend/docs/README.md
@@ -41,7 +41,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#weight" title="Weight">Weight</a>" : <i>Integer</i>,
         "<a href="#serviceid" title="ServiceId">ServiceId</a>" : <i>String</i>,
         "<a href="#backendname" title="BackendName">BackendName</a>" : <i>String</i>,
-        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>String</i>,
+        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>Double</i>,
     }
 }
 </pre>
@@ -80,7 +80,7 @@ Properties:
     <a href="#weight" title="Weight">Weight</a>: <i>Integer</i>
     <a href="#serviceid" title="ServiceId">ServiceId</a>: <i>String</i>
     <a href="#backendname" title="BackendName">BackendName</a>: <i>String</i>
-    <a href="#versionid" title="VersionId">VersionId</a>: <i>String</i>
+    <a href="#versionid" title="VersionId">VersionId</a>: <i>Double</i>
 </pre>
 
 ## Properties
@@ -381,11 +381,11 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### VersionId
 
-Alphanumeric string identifying the service version.
+Id identifying the service version.
 
 _Required_: Yes
 
-_Type_: String
+_Type_: Double
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Services-Backend/example-inputs/inputs_1_create.json
+++ b/Fastly-Services-Backend/example-inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
   "ServiceId": "<FASTLY_SERVICE_ID>",
-  "VersionId": "<FASTLY_VERSION_ID>",
+  "VersionId": <FASTLY_VERSION_ID>,
   "Name": "aws.amazon.com",
   "Address": "aws.amazon.com",
   "Comment": "Hello AWS",

--- a/Fastly-Services-Backend/fastly-services-backend.json
+++ b/Fastly-Services-Backend/fastly-services-backend.json
@@ -170,8 +170,8 @@
       "type": "string"
     },
     "VersionId": {
-      "description": "Alphanumeric string identifying the service version.",
-      "type": "string"
+      "description": "Id identifying the service version.",
+      "type": "number"
     },
     "UpdatedAt": {
       "description": "Date and time in ISO 8601 format. Read-only.",

--- a/Fastly-Services-Backend/src/models.ts
+++ b/Fastly-Services-Backend/src/models.ts
@@ -279,12 +279,12 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'VersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'versionId', value, obj, []),
+            transformValue(Number, 'versionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    versionId?: Optional<string>;
+    versionId?: Optional<number>;
     @Expose({ name: 'CreatedAt' })
     @Transform(
         (value: any, obj: any) =>

--- a/Fastly-Services-Domain/docs/README.md
+++ b/Fastly-Services-Domain/docs/README.md
@@ -41,7 +41,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Services-Healthcheck/docs/README.md
+++ b/Fastly-Services-Healthcheck/docs/README.md
@@ -25,7 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#timeout" title="Timeout">Timeout</a>" : <i>Integer</i>,
         "<a href="#window" title="Window">Window</a>" : <i>Integer</i>,
         "<a href="#serviceid" title="ServiceId">ServiceId</a>" : <i>String</i>,
-        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>String</i>,
+        "<a href="#versionid" title="VersionId">VersionId</a>" : <i>Double</i>,
         "<a href="#healthcheckname" title="HealthcheckName">HealthcheckName</a>" : <i>String</i>,
     }
 }
@@ -49,7 +49,7 @@ Properties:
     <a href="#timeout" title="Timeout">Timeout</a>: <i>Integer</i>
     <a href="#window" title="Window">Window</a>: <i>Integer</i>
     <a href="#serviceid" title="ServiceId">ServiceId</a>: <i>String</i>
-    <a href="#versionid" title="VersionId">VersionId</a>: <i>String</i>
+    <a href="#versionid" title="VersionId">VersionId</a>: <i>Double</i>
     <a href="#healthcheckname" title="HealthcheckName">HealthcheckName</a>: <i>String</i>
 </pre>
 
@@ -191,11 +191,11 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### VersionId
 
-Alphanumeric string identifying the service version.
+Id identifying the service version.
 
 _Required_: Yes
 
-_Type_: String
+_Type_: Double
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/Fastly-Services-Healthcheck/example-inputs/inputs_1_create.json
+++ b/Fastly-Services-Healthcheck/example-inputs/inputs_1_create.json
@@ -1,6 +1,6 @@
 {
   "ServiceId": "<FASTLY_SERVICE_ID>",
-  "VersionId": "<FASTLY_VERSION_ID>",
+  "VersionId": <FASTLY_VERSION_ID>,
   "Name": "Test healthcheck",
   "CheckInterval": 60000,
   "Host": "aws.amazon.com",

--- a/Fastly-Services-Healthcheck/fastly-services-healthcheck.json
+++ b/Fastly-Services-Healthcheck/fastly-services-healthcheck.json
@@ -23,8 +23,8 @@
       "type": "string"
     },
     "VersionId": {
-      "description": "Alphanumeric string identifying the service version.",
-      "type": "string"
+      "description": "Id identifying the service version.",
+      "type": "number"
     },
     "CheckInterval": {
       "description": "How often to run the healthcheck in milliseconds.",

--- a/Fastly-Services-Healthcheck/src/models.ts
+++ b/Fastly-Services-Healthcheck/src/models.ts
@@ -135,12 +135,12 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'VersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'versionId', value, obj, []),
+            transformValue(Number, 'versionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    versionId?: Optional<string>;
+    versionId?: Optional<number>;
     @Expose({ name: 'HealthcheckName' })
     @Transform(
         (value: any, obj: any) =>

--- a/Fastly-Services-Service/docs/README.md
+++ b/Fastly-Services-Service/docs/README.md
@@ -37,7 +37,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/Fastly-Services-Service/fastly-services-service.json
+++ b/Fastly-Services-Service/fastly-services-service.json
@@ -94,11 +94,11 @@
     },
     "ActiveVersionId": {
       "description": "The number of the active version.",
-      "type": "string"
+      "type": "number"
     },
     "LatestVersionId": {
       "description": "The number of the latest version.",
-      "type": "string"
+      "type": "number"
     },
     "Type": {
       "$ref": "#/definitions/Type"

--- a/Fastly-Services-Service/src/handlers.ts
+++ b/Fastly-Services-Service/src/handlers.ts
@@ -6,6 +6,7 @@ import {FastlyApiObject, fastlyNotFoundError, ResponseWithHttpInfo} from '../../
 // @ts-ignore
 import * as Fastly from "fastly";
 import {version} from '../package.json';
+import {integer} from "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib";
 
 // The types below are only partial representation of what the API is returning. It's only needed for TypeScript niceties
 type Service = {
@@ -91,8 +92,8 @@ class Resource extends AbstractFastlyResource<ResourceModel, Service, Service, S
             return model;
         }
         if (Array.isArray(from.versions)) {
-            model.activeVersionId = from.versions.find(v => v.active === true)?.number.toString() || '';
-            model.latestVersionId = from.versions.reduce((max, v) => max.number > v.number ? max : v)?.number.toString() || '';
+            model.activeVersionId = from.versions.find(v => v.active === true)?.number || 0;
+            model.latestVersionId = from.versions.reduce((max, v) => max.number > v.number ? max : v)?.number || 0;
         }
 
         const resourceModel = new ResourceModel({

--- a/Fastly-Services-Service/src/models.ts
+++ b/Fastly-Services-Service/src/models.ts
@@ -50,21 +50,21 @@ export class ResourceModel extends BaseModel {
     @Expose({ name: 'ActiveVersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'activeVersionId', value, obj, []),
+            transformValue(Number, 'activeVersionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    activeVersionId?: Optional<string>;
+    activeVersionId?: Optional<number>;
     @Expose({ name: 'LatestVersionId' })
     @Transform(
         (value: any, obj: any) =>
-            transformValue(String, 'latestVersionId', value, obj, []),
+            transformValue(Number, 'latestVersionId', value, obj, []),
         {
             toClassOnly: true,
         }
     )
-    latestVersionId?: Optional<string>;
+    latestVersionId?: Optional<number>;
     @Expose({ name: 'Type' })
     @Transform(
         (value: any, obj: any) =>


### PR DESCRIPTION
The version Id returned by the Fastly::Services::Version resource is of type integer but some resources expected a string.  This updates all resources to expect an integer.